### PR TITLE
Use environment variable for API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_INVOICE_API_URL=https://your-api-url.com/api/invoice/generate

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-.env*
+.env
 
 .vercel
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,17 @@ cd invoice-generator-fe
 npm install
 # or
 yarn install
+
+# Set up environment variables
+cp .env.example .env.local
+# Edit .env.local with your API URL
 ```
+
+### Environment Variables
+
+Copy `.env.example` to `.env.local` and configure the following:
+
+- `NEXT_PUBLIC_INVOICE_API_URL`: Your invoice generation API endpoint
 
 ### Running the Development Server
 

--- a/app/services/invoiceApi.ts
+++ b/app/services/invoiceApi.ts
@@ -23,7 +23,7 @@ export interface InvoicePayload {
 }
 
 export class InvoiceApiService {
-    private static readonly API_URL = 'https://mv7vubgi4i.execute-api.us-east-1.amazonaws.com/prod/api/invoice/generate';
+    private static readonly API_URL = process.env.NEXT_PUBLIC_INVOICE_API_URL || 'https://mv7vubgi4i.execute-api.us-east-1.amazonaws.com/prod/api/invoice/generate';
 
     static async generateInvoice(payload: InvoicePayload): Promise<Blob> {
         const response = await fetch(this.API_URL, {


### PR DESCRIPTION
Replace the hardcoded API URL with an environment variable to enhance configurability and allow easier updates to the API endpoint. Update documentation to reflect the new setup process for environment variables.